### PR TITLE
fix rawtext referenced before assignment error

### DIFF
--- a/hocr-pdf
+++ b/hocr-pdf
@@ -81,6 +81,8 @@ def add_text_layer(pdf, image, height, dpi):
           innerword = word[0]
           if innerword.text is not None:
             rawtext = innerword.text.strip()
+          else:
+            continue  
         except:
           continue
       font_width = pdf.stringWidth(rawtext, 'invisible', 8)


### PR DESCRIPTION
This is a potential fix for #30 where rawtext gets referenced without having been defined. If innerword.txt is None then rawtext will never get defined. This patch simply continues if innerword.text is also None. I'm not certain this is the best fix, but this works for me.

The issue arises because sometimes tesseract outputs hOCR where an ocrx_word just has a single space. the cases I've seen are with images of text that tesseract has lots of problems with.

```html
<div class='ocr_carea' id='block_1_1' title="bbox 118 3884 122 5088">
    <p class='ocr_par' dir='ltr' id='par_1_1' title="bbox 118 3884 122 5088">
     <span class='ocr_line' id='line_1_1' title="bbox 118 3884 122 5088; baseline 0 0"><span class='ocrx_word' id='word_1_1' title='bbox 118 3884 122 5088; x_wconf 95' lang='eng' dir='ltr'><strong><em> </em></strong></span> 
     </span>
    </p>
   </div>
```