### PR TITLE
Python3 ready

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 language: python
+python:
+  - "2.7"
+  - "3.4"
 cache:
   directories:
     - /home/travis/virtualenv/python2.7/lib/python2.7/site-packages
+    - /home/travis/virtualenv/python3.4/lib/python3.4/site-packages
 install:
   - pip install -r requirements.txt
+  - 2to3 --write --nobackup hocr-*
   - python setup.py install
-  - pip install pep8
+  # - pip install pep8
 script: 
   - ./test/tsht
-  - pep8 hocr-* setup.py; true
+  # - pep8 hocr-* setup.py; true

--- a/hocr-check
+++ b/hocr-check
@@ -70,13 +70,12 @@ if len(sys.argv)<1:
     
 optlist,args = getopt.getopt(sys.argv[1:],"o")
 nooverlap = (assoc('-o',optlist)=='')
-if len(args)>0: stream = open(args[0])
+if len(args)>0: doc = html.parse(args[0])
 elif len(args)>1:
     print("Can only check one file at a time")
     print_usage()
     sys.exit(1)
-else: stream = sys.stdin
-doc = html.fromstring(stream.read())
+else: doc = html.parse(sys.stdin)
 
 ################################################################
 ### XML structure checks

--- a/hocr-check
+++ b/hocr-check
@@ -71,7 +71,10 @@ if len(sys.argv)<1:
 optlist,args = getopt.getopt(sys.argv[1:],"o")
 nooverlap = (assoc('-o',optlist)=='')
 if len(args)>0: stream = open(args[0])
-elif len(args)>1: raise "can only check one file at a time"
+elif len(args)>1:
+    print("Can only check one file at a time")
+    print_usage()
+    sys.exit(1)
 else: stream = sys.stdin
 doc = html.fromstring(stream.read())
 

--- a/hocr-eval-geom
+++ b/hocr-eval-geom
@@ -3,7 +3,7 @@
 # compute statistics about the quality of the geometric segmentation
 # at the level of the given OCR element
 
-import sys,os,string,re,getopt
+import sys,os,re,getopt
 from lxml import html
 
 ### general utilities
@@ -17,7 +17,7 @@ def assoc(key,list):
 
 def get_text(node):
     textnodes = node.xpath(".//text()")
-    s = string.join([text for text in textnodes])
+    s = ''.join([text for text in textnodes])
     return re.sub(r'\s+',' ',s)
 
 def get_prop(node,name):

--- a/hocr-eval-geom
+++ b/hocr-eval-geom
@@ -101,7 +101,7 @@ def boxstats(truths,actuals):
         if len(matching)<1:
             missing += 1
         elif len(matching)>1:
-            raise "multiple close matches: your segmentation files are bad"
+            raise AttributeError("Multiple close matches: your segmentation files are bad")
         else:
             error += 1.0-matching[0]
             count += 1
@@ -119,8 +119,8 @@ for truth,actual in pages:
     aobjs = actual.xpath("//*[@class='%s']"%element)
     tboxes = [get_bbox(n) for n in tobjs]
     if check_bad_partition(tboxes):
-        raise "ground truth data is not an acceptable segmentation"
+        raise ValueError("Ground truth data is not an acceptable segmentation")
     aboxes = [get_bbox(n) for n in aobjs]
     if check_bad_partition(aboxes):
-        raise "actual data is not an acceptable segmentation"
+        raise ValueError("Actual data is not an acceptable segmentation")
     print boxstats(tboxes,aboxes),boxstats(aboxes,tboxes)

--- a/hocr-eval-lines
+++ b/hocr-eval-lines
@@ -3,7 +3,7 @@
 # compute statistics about the quality of the geometric segmentation
 # at the level of the given OCR element
 
-import sys,os,string,re,getopt
+import sys,os,re,getopt
 from lxml import html
 from pylab import array,zeros,reshape
 
@@ -18,7 +18,7 @@ def assoc(key,list):
 
 def get_text(node):
     textnodes = node.xpath(".//text()")
-    s = string.join([text for text in textnodes])
+    s = ''.join([text for text in textnodes])
     return re.sub(r'\s+',' ',s)
 
 simp_re = re.compile(r'[^a-zA-Z0-9.,!?:;]+')

--- a/hocr-extract-g1000
+++ b/hocr-extract-g1000
@@ -111,56 +111,56 @@ class docHandler(xml.sax.handler.ContentHandler):
         self.element = element
         self.regex = regex
     def startDocument(self):
-	self.total = 0
-	self.pageno = -1
-	self.text = None
-	self.depth = 0
-	self.start = -1
+        self.total = 0
+        self.pageno = -1
+        self.text = None
+        self.depth = 0
+        self.start = -1
         self.copied = {}
     def endDocument(self):
-	pass
+        pass
     def startElement(self,name,attrs):
-	self.depth += 1
-	if attrs.get("class","")=="ocr_page":
-	    self.lineno = -1
-	    self.pageno += 1
+        self.depth += 1
+        if attrs.get("class","")=="ocr_page":
+            self.lineno = -1
+            self.pageno += 1
             self.page = image_list[self.pageno]
-	    self.image = Image.open(self.page)
-	if attrs.get("class","")==self.element:
-	    self.lineno += 1
-	    props = attrs.get("title","")
-	    self.bbox = get_prop(props,"bbox")
-	    self.start = self.depth
-	    self.text = u""
+            self.image = Image.open(self.page)
+        if attrs.get("class","")==self.element:
+            self.lineno += 1
+            props = attrs.get("title","")
+            self.bbox = get_prop(props,"bbox")
+            self.start = self.depth
+            self.text = u""
     def endElement(self,name):
-	if self.depth==self.start:
-	    if len(self.text)>=min_len and \
+        if self.depth==self.start:
+            if len(self.text)>=min_len and \
                     len(self.text)<=max_len and \
                     re.match(self.regex,self.text) and \
                     check_dict(dict,self.text):
-		print self.page,self.bbox,self.text.encode("utf-8")
-		w,h = self.image.size
-		x0,y0,x1,y1 = [int(s) for s in self.bbox.split()]
-		assert y0<y1 and x0<x1 and x1<=w and y1<=h
-		x0 = max(0,x0-pad)
-		y0 = max(0,y0-pad)
-		x1 = min(w,x1+pad)
-		y1 = min(h,y1+pad)
-		limage = self.image.crop((x0,y0,x1,y1))
-		base = output_pattern%(self.pageno,self.lineno)
+                print self.page,self.bbox,self.text.encode("utf-8")
+                w,h = self.image.size
+                x0,y0,x1,y1 = [int(s) for s in self.bbox.split()]
+                assert y0<y1 and x0<x1 and x1<=w and y1<=h
+                x0 = max(0,x0-pad)
+                y0 = max(0,y0-pad)
+                x1 = min(w,x1+pad)
+                y1 = min(h,y1+pad)
+                limage = self.image.crop((x0,y0,x1,y1))
+                base = output_pattern%(self.pageno,self.lineno)
                 basedir = os.path.dirname(base)
                 if not os.path.exists(basedir):  os.mkdir(basedir)
                 limage.save(base+"."+output_format)
-		write_string(base+".txt",self.text)
-		write_string(base+".bbox",self.bbox)
-		self.total += 1
-		if self.total>=max_lines: sys.exit(0)
-	    self.text = None
-	    self.start = -1
-	self.depth -= 1
+                write_string(base+".txt",self.text)
+                write_string(base+".bbox",self.bbox)
+                self.total += 1
+                if self.total>=max_lines: sys.exit(0)
+            self.text = None
+            self.start = -1
+        self.depth -= 1
     def characters(self,str,start,end):
-	if self.text!=None:
-	    self.text += str[start:end]
+        if self.text!=None:
+            self.text += str[start:end]
 
 parser = xml.sax.make_parser()
 stream = os.popen("tidy -q -wrap 9999 -asxhtml < %s 2> /tmp/tidy_errs"%hocr,"r")

--- a/hocr-extract-images
+++ b/hocr-extract-images
@@ -26,13 +26,14 @@ def get_prop(node,name):
     return None
 
 def print_usage():
-    print "usage: %s [-b image-dir] [-p file-pattern] [-e element-name] hocr-file"%sys.argv[0]
-    sys.exit(0)
+    print "Usage: %s [-b image-dir] [-p file-pattern] [-e element-name] [hocr-file]"%sys.argv[0]
 
 if len(sys.argv)>1 and (sys.argv[1] == '-h' or sys.argv[1] == '--help'):
     print_usage()
+    sys.exit(0)
 if len(sys.argv)<2 and sys.stdin.isatty():
     print_usage()
+    sys.exit(0)
 optlist,args = getopt.getopt(sys.argv[1:],"b:p:e:")
 print args
 
@@ -44,7 +45,10 @@ tpattern = pattern + '.txt'
 if pattern[-4] == '.':
     tpattern = pattern[:-3] + 'txt'
 
-if len(args)>1: raise "too many args"
+if len(args)>1:
+    print("Error: Too many args")
+    print_usage()
+    sys.exit(1)
 if len(args)==1: stream = open(args[0])
 else: stream = sys.stdin
 

--- a/hocr-extract-images
+++ b/hocr-extract-images
@@ -2,7 +2,7 @@
 
 # extract the images and texts within all the ocr_line elements within the hOCR file
 
-import sys,os,string,re,getopt,codecs
+import sys,os,re,getopt,codecs
 from PIL import Image
 from lxml import html
 
@@ -13,7 +13,7 @@ def assoc(key,list):
 
 def get_text(node):
     textnodes = node.xpath('.//text()')
-    s = string.join([text for text in textnodes])
+    s = ''.join([text for text in textnodes])
     return re.sub(r'\s+',' ',s)
 
 def get_prop(node,name):
@@ -35,7 +35,6 @@ if len(sys.argv)<2 and sys.stdin.isatty():
     print_usage()
     sys.exit(0)
 optlist,args = getopt.getopt(sys.argv[1:],"b:p:e:")
-print args
 
 basename = assoc('-b',optlist)
 pattern = assoc('-p',optlist) or 'line-%03d.png'
@@ -49,10 +48,9 @@ if len(args)>1:
     print("Error: Too many args")
     print_usage()
     sys.exit(1)
-if len(args)==1: stream = open(args[0])
-else: stream = sys.stdin
+if len(args)==1: doc = html.parse(args[0])
+else: doc = html.parse(sys.stdin)
 
-doc = html.fromstring(stream.read())
 pages = doc.xpath('//*[@class="ocr_page"]')
 for page in pages:
     iname = get_prop(page,'file')
@@ -64,7 +62,7 @@ for page in pages:
         print "not found:",iname
         sys.exit(1)
     image = Image.open(iname)
-    print image
+    #  print image
     lines = page.xpath("//*[@class='%s']"%element)
     lcount = 1
     for line in lines:

--- a/hocr-lines
+++ b/hocr-lines
@@ -2,12 +2,12 @@
 
 # extract the text within all the ocr_line elements within the hOCR file
 
-import sys,os,string,re
+import sys,os,re
 from lxml import html
 
 def get_text(node):
     textnodes = node.xpath(".//text()")
-    s = string.join([text for text in textnodes])
+    s = ''.join([text for text in textnodes])
     return re.sub(r'\s+',' ',s)
 
 if len(sys.argv)>1 and (sys.argv[1] == '-h' or sys.argv[1] == '--help'):

--- a/hocr-lines
+++ b/hocr-lines
@@ -14,10 +14,9 @@ if len(sys.argv)>1 and (sys.argv[1] == '-h' or sys.argv[1] == '--help'):
     print "Usage:", sys.argv[0], "file.html"
     sys.exit(0)
 
-if len(sys.argv)>1: stream = open(sys.argv[1])
-else: stream = sys.stdin
-doc = html.fromstring(stream.read())
-lines = doc.xpath("//*[@class='ocr_line']")
+if len(sys.argv)>1: doc = html.parse(sys.argv[1])
+else: doc = html.parse(sys.stdin)
 
+lines = doc.xpath("//*[@class='ocr_line']")
 for line in lines:
     print get_text(line)

--- a/hocr-merge-dc
+++ b/hocr-merge-dc
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import sys,os,string,re
+import sys,os,re
 import xml
 from lxml import html, etree
 
@@ -14,7 +14,7 @@ dcknown = [
 
 def get_text(node):
     textnodes = node.xpath(".//text()")
-    s = string.join([text for text in textnodes])
+    s = "".join([text for text in textnodes])
     return re.sub(r'\s+',' ',s)
 
 def print_usage():

--- a/hocr-pdf
+++ b/hocr-pdf
@@ -31,10 +31,21 @@ from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
 from xml.etree.ElementTree import ElementTree, ParseError
 
+class StdoutWrapper:
+    """
+    Wrapper around stdout that ensures 'bytes' data is decoded
+    to 'latin1' (0x00 - 0xff) before writing out. This is necessary for
+    the invisible font to be injected as bytes but written out as a string.
+    """
+    def write(self, data, *args, **kwargs):
+        if bytes != str and isinstance(data, bytes):
+            data = data.decode('latin1')
+        sys.stdout.write(data)
+
 def export_pdf(playground, default_dpi):
   """Create a searchable PDF from a pile of HOCR + JPEG"""
   load_invisible_font()
-  pdf = Canvas(sys.stdout, pageCompression=1)
+  pdf = Canvas(StdoutWrapper(), pageCompression=1)
   pdf.setCreator('hocr-tools')
   pdf.setTitle(os.path.basename(playground))
   images = sorted(glob.glob(os.path.join(playground, '*.jpg')))
@@ -131,6 +142,7 @@ CMGjwvxTsr74/f/F95m3TH9x8o0/TU//N+7/D/ScVcA=
 """.encode('latin1')
   uncompressed = bytearray(zlib.decompress(base64.decodestring(font)))
   ttf = io.BytesIO(uncompressed)
+  setattr(ttf ,"name", "(invisible.ttf)")
   pdfmetrics.registerFont(TTFont('invisible', ttf))
 
 if __name__ == "__main__":

--- a/hocr-pdf
+++ b/hocr-pdf
@@ -20,7 +20,7 @@
 import sys
 import glob
 import os.path
-import cStringIO
+import io
 import base64
 import zlib
 import re
@@ -128,12 +128,13 @@ pL26nlWN2K+W1LhRjxlVGKmRTFYVo7CiJug09E+GJb+QocMCPMWBK1wvEOfRFF2U0klK8CppqqvG
 pylRc2Zn+XDQWZIL8iO5KC9S+1RekOex1uOyZGR/w/Hf1lhzqVfFsxE39B/ws7Rm3N3nDrhPuMfc
 w3R/aE28KsfY2J+RPNp+j+KaOoCey4h+Dd48b9O5G0v2K7j0AM6s+5WQ/E0wVoK+pA6/3bup7bJf
 CMGjwvxTsr74/f/F95m3TH9x8o0/TU//N+7/D/ScVcA=
-"""
-  ttf = cStringIO.StringIO(zlib.decompress(base64.decodestring(font)))
+""".encode('latin1')
+  uncompressed = bytearray(zlib.decompress(base64.decodestring(font)))
+  ttf = io.BytesIO(uncompressed)
   pdfmetrics.registerFont(TTFont('invisible', ttf))
 
 if __name__ == "__main__":
   if len(sys.argv) == 1:
-    print("Usage: %s <imgdir>\n" % os.path.basename(sys.argv[0]))
+    print(("Usage: %s <imgdir>\n" % os.path.basename(sys.argv[0])))
   else:
     export_pdf(sys.argv[1], 300)

--- a/hocr-pdf
+++ b/hocr-pdf
@@ -147,6 +147,6 @@ CMGjwvxTsr74/f/F95m3TH9x8o0/TU//N+7/D/ScVcA=
 
 if __name__ == "__main__":
   if len(sys.argv) == 1:
-    print(("Usage: %s <imgdir>\n" % os.path.basename(sys.argv[0])))
+    print("Usage: %s <imgdir>\n" % os.path.basename(sys.argv[0]))
   else:
     export_pdf(sys.argv[1], 300)

--- a/hocr-split
+++ b/hocr-split
@@ -26,8 +26,7 @@ if len(sys.argv)!=3:
 pattern = sys.argv[2]
 assert re.search('%[0-9]*d',pattern)
 
-stream = open(sys.argv[1])
-doc = html.fromstring(stream.read())
+doc = html.parse(sys.argv[1])
 pages = doc.xpath("//*[@class='ocr_page']")
 assert pages!=[]
 
@@ -37,7 +36,5 @@ for new_page in pages:
     container_pages = container.xpath("//*[@class='ocr_page']")
     for page in container_pages: container.remove(page)
     container.append(new_page)
-    stream = open(pattern % index, "w")
-    stream.write(etree.tostring(doc, pretty_print=True))
-    stream.close()
+    doc.write((pattern % index), pretty_print=True)
     index += 1


### PR DESCRIPTION
These changes will make hocr-tools ready for Python 3.4, as outlined in https://github.com/tmbdev/hocr-tools/issues/37

Note that the code is **not** fully compatible with Python 3.4, since this would require correcting all the `print` calls and I wanted to keep the source as close to its current state as possible. The `2to3` tool bundled with Python can fix the source code automatically however and the converted source runs fine in 2.7 and 3.4 (c.f. [travis.yml](https://github.com/kba/hocr-tools/blob/python3-ready/.travis.yml#L12)).

Most important changes:
* Don't use lxml's `fromstring`/`tostring` but let lxml handle the distinction of filename and `stdin`/`stdout`
* Use `io.BytesIO` instead of `cStringIO` (which works in 2.7 because there is no distinction between strings and binary data, but is conceptually flawed)
* Don't use `string.join(sep, list)` which is equivalent to `sep.join(list)` and has been since at least 2.5
* Don't raise strings  but instances of real exceptions. It's pythonic and makes the code cleaner IMHO. Using exceptions for CLI argument errors seems overkill though, I replaced those with a helpful message and `sys.exit(1)`

The only hack-ish solution is a workaround for a bug in reportlab that will make `hocr-pdf` break in 3.x: The invisible font is loaded from a base64-encoded gzipped blob. reportlab does accept file-like objects for the filename argument to `TTFont` and loads the font properly. It will fail to decode it back to a `latin1` string when saving though. I've opened an [upstream PR for that](https://bitbucket.org/rptlab/reportlab/pull-requests/33/catch-pdfdata-being-byte/diff) but in the meantime, wrapping `sys.stdout` will work around this and not interfere with existing code.