### PR TITLE
Setup for release on PyPI

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ VERSION = '1.0.0'
 import glob
 from setuptools import setup
 setup(
-    name = "hocr_tools",
+    name = "hocr-tools",
     version = VERSION,
     description = 'Advanced tools for hOCR integration',
     author = 'Thomas Breuel',

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,17 @@
 #!/usr/bin/env python
 
+VERSION = '1.0.0'
+
 import glob
 from setuptools import setup
 setup(
     name = "hocr_tools",
-    version = "1.2.2",
+    version = VERSION,
     description = 'Advanced tools for hOCR integration',
     author = 'Thomas Breuel',
     author_email = 'tmbdev@gmail.com',
     url = 'https://github.com/tmbdev/hocr-tools',
-    download_url = 'https://github.com/tmbdev/hocr-tools/tarball/1.2.2',
+    download_url = 'https://github.com/tmbdev/hocr-tools/tarball/v' + VERSION,
     classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,11 @@ setup(
         'Topic :: Scientific/Engineering :: Image Recognition',
         'Topic :: Utilities',
     ],
+    install_requires = [
+        'Pillow',
+        'lxml',
+        'reportlab',
+        'matplotlib',
+    ],
     scripts = [c for c in glob.glob("hocr-*")]
 )

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,22 @@ import glob
 from setuptools import setup
 setup(
     name = "hocr_tools",
-    version = "0.1",
-    author = 'Thomas Breuel',
+    version = "1.2.2",
     description = 'Advanced tools for hOCR integration',
+    author = 'Thomas Breuel',
+    author_email = 'tmbdev@gmail.com',
+    url = 'https://github.com/tmbdev/hocr-tools',
+    download_url = 'https://github.com/tmbdev/hocr-tools/tarball/1.2.2',
+    classifiers = [
+        'Development Status :: 5 - Production/Stable',
+        'Environment :: Console',
+        'Intended Audience :: End Users/Desktop',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.7',
+        'Topic :: Multimedia :: Graphics :: Graphics Conversion',
+        'Topic :: Scientific/Engineering :: Image Recognition',
+        'Topic :: Utilities',
+    ],
     scripts = [c for c in glob.glob("hocr-*")]
 )

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ setup(
     version = VERSION,
     description = 'Advanced tools for hOCR integration',
     author = 'Thomas Breuel',
-    author_email = 'tmbdev@gmail.com',
+    maintainer = 'Konstantin Baierer',
+    maintainer_email = 'konstantin.baierer@gmail.com',
     url = 'https://github.com/tmbdev/hocr-tools',
     download_url = 'https://github.com/tmbdev/hocr-tools/tarball/v' + VERSION,
     classifiers = [


### PR DESCRIPTION
Once the tools are versioned (#43), they can be released to [PyPI](https://pypi.python.org) for easy installation with pip.

Uploading a source distribution [basically works with the configuration in this PR](https://testpypi.python.org/pypi?:action=display&name=hocr_tools&version=1.2.2).

Open Questions:

* [x] <del>Name: `hocr-tools` with a dash is possible but if the project is properly packaged in the future (#42), it would be wise to have a name that is a valid module name</del> That is not really a problem, seems to be fairly common actually.
* [x] <del>What to put in `author` / `author_email`? I started with @tmbdev's credentials</del> I removed the author_email, PyPI warns on register but still carries out the upload, at least for test.
* [ ] Specify requirements in `setup.py` or in `requirements.txt`? Could be both, discussed [here](https://packaging.python.org/requirements/#install-requires-vs-requirements-files)
* [x] <del>Who manages the uploads?</del> I will