### PR TITLE
Use lxml.etree, iterate ocr_line > ocr_word

### DIFF
--- a/hocr-pdf
+++ b/hocr-pdf
@@ -29,7 +29,7 @@ from PIL import Image
 from reportlab.pdfgen.canvas import Canvas
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
-from xml.etree.ElementTree import ElementTree, ParseError
+from lxml import etree
 
 class StdoutWrapper:
     """
@@ -70,11 +70,8 @@ def add_text_layer(pdf, image, height, dpi):
   p1 = re.compile('bbox((\s+\d+){4})')
   p2 = re.compile('baseline((\s+[\d\.\-]+){2})')
   hocrfile = os.path.splitext(image)[0] + ".hocr"
-  hocr = ElementTree()
-  hocr.parse(hocrfile)
-  for line in hocr.findall(".//{http://www.w3.org/1999/xhtml}span"):
-    if line.attrib['class'] != 'ocr_line':
-      continue
+  hocr = etree.parse(hocrfile)
+  for line in hocr.xpath('//*[@class="ocr_line"]'):
     linebox = p1.search(line.attrib['title']).group(1).split()
     try:
       baseline = p2.search(line.attrib['title']).group(1).split()
@@ -82,20 +79,9 @@ def add_text_layer(pdf, image, height, dpi):
       baseline = [ 0, 0 ]
     linebox = [float(i) for i in linebox]
     baseline = [float(i) for i in baseline]
-    for word in line:
-      if word.attrib['class'] != 'ocrx_word':
-        continue
-      if word.text is not None:
-        rawtext = word.text.strip()
-      else:
-        try:
-          innerword = word[0]
-          if innerword.text is not None:
-            rawtext = innerword.text.strip()
-          else:
-            continue  
-        except:
-          continue
+    for word in line.xpath('.//*[@class="ocrx_word"]'):
+      rawtext = word.xpath('./text()')[0]
+      #  sys.stderr.write("WORD: '%s', type '%s'\n" % (rawtext, type(rawtext)))
       font_width = pdf.stringWidth(rawtext, 'invisible', 8)
       if font_width <= 0:
         continue

--- a/hocr-pdf
+++ b/hocr-pdf
@@ -29,7 +29,7 @@ from PIL import Image
 from reportlab.pdfgen.canvas import Canvas
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
-from lxml import etree
+from lxml import etree, html
 
 class StdoutWrapper:
     """
@@ -70,7 +70,7 @@ def add_text_layer(pdf, image, height, dpi):
   p1 = re.compile('bbox((\s+\d+){4})')
   p2 = re.compile('baseline((\s+[\d\.\-]+){2})')
   hocrfile = os.path.splitext(image)[0] + ".hocr"
-  hocr = etree.parse(hocrfile)
+  hocr = etree.parse(hocrfile, html.XHTMLParser())
   for line in hocr.xpath('//*[@class="ocr_line"]'):
     linebox = p1.search(line.attrib['title']).group(1).split()
     try:
@@ -80,8 +80,9 @@ def add_text_layer(pdf, image, height, dpi):
     linebox = [float(i) for i in linebox]
     baseline = [float(i) for i in baseline]
     for word in line.xpath('.//*[@class="ocrx_word"]'):
-      rawtext = word.xpath('./text()')[0]
-      #  sys.stderr.write("WORD: '%s', type '%s'\n" % (rawtext, type(rawtext)))
+      rawtext = word.text_content().strip()
+      if rawtext == '':
+          continue
       font_width = pdf.stringWidth(rawtext, 'invisible', 8)
       if font_width <= 0:
         continue


### PR DESCRIPTION
[Move from https://github.com/UB-Mannheim/hocr-tools/pull/19 here. ]

@kba writes:

This should not change existing behavior, but additionally allow processing non-XHTML-namespaced non-`span` `ocr_line`.

In the long run, integrating the code from [jbarlow83/OCRmyPDF](https://github.com/jbarlow83/OCRmyPDF) would be useful. Making the assumptions hocr-pdf makes on the hocr explicit would help too.