### PR TITLE
Add Dockerfile for testing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+*.sh eol=lf
+*.tsht eol=lf
+hocr-* eol=lf
+tsht eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,0 @@
-*.sh eol=lf
-*.tsht eol=lf
-hocr-* eol=lf
-tsht eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . /usr/src/app
 
-RUN ["python", "setup.py", "install"]
+RUN python setup.py install
 
 CMD ./test/tsht

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,3 +17,5 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . /usr/src/app
 
 RUN ["python", "setup.py", "install"]
+
+CMD ./test/tsht

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+#
+# Build: docker build -t hocr-tools-app .
+# Start: docker run -it --rm -v ${PWD}:/usr/src/app hocr-tools-app bash
+# Test: ./test/tsht
+#
+
+FROM python:2
+
+RUN apt-get update && apt-get install -y pdfgrep
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY requirements.txt /usr/src/app/
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . /usr/src/app
+
+RUN ["python", "setup.py", "install"]


### PR DESCRIPTION
I created this `Dockerfile` for being able to test the current code and also new PR. Together with the `.gitattributes` this also works under windows using docker. What do you think, is this useful for others as well?

I don't think we need to share an image, because the purpose would more be for testing code.

However, I could imagine to create a docker image which bundles several tools around hocr and ocropus, see also #25, at some time later...