### PR TITLE
setup.py: Bump version 1.0.0 -> 1.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-VERSION = '1.0.0'
+VERSION = '1.0.1'
 
 import glob
 from setuptools import setup


### PR DESCRIPTION
Bumps the setup.py version, https://pypi.python.org/pypi/hocr-tools