### PR TITLE
[Coding style] PEP 8: Multiple imports should not be on one line (fix #68)

### DIFF
--- a/hocr-check
+++ b/hocr-check
@@ -2,7 +2,12 @@
 
 # check the given file for conformance with the hOCR format spec
 
-import sys,os,string,re,getopt
+import getopt
+import os
+import re
+import string
+import sys
+
 from lxml import html
 
 ################################################################

--- a/hocr-combine
+++ b/hocr-combine
@@ -1,7 +1,11 @@
 #!/usr/bin/env python
 
-import sys,os,string,re
-from lxml import html, etree
+import os
+import re
+import string
+import sys
+
+from lxml import etree, html
 
 ################################################################
 ### main program

--- a/hocr-eval
+++ b/hocr-eval
@@ -4,10 +4,16 @@
 # compute statistics about the quality of the geometric segmentation
 # at the level of the given OCR element
 
-import sys,os,codecs,string,re,getopt
-from PIL import Image,ImageDraw
+import codecs
+import getopt
+import os
+import re
+import string
+import sys
+
 from lxml import html
-from pylab import array,zeros,reshape
+from pylab import array, reshape, zeros
+from PIL import Image, ImageDraw
 
 ################################################################
 ### library

--- a/hocr-eval-geom
+++ b/hocr-eval-geom
@@ -3,7 +3,11 @@
 # compute statistics about the quality of the geometric segmentation
 # at the level of the given OCR element
 
-import sys,os,re,getopt
+import getopt
+import os
+import re
+import sys
+
 from lxml import html
 
 ### general utilities

--- a/hocr-eval-lines
+++ b/hocr-eval-lines
@@ -3,9 +3,13 @@
 # compute statistics about the quality of the geometric segmentation
 # at the level of the given OCR element
 
-import sys,os,re,getopt
+import getopt
+import os
+import re
+import sys
+
 from lxml import html
-from pylab import array,zeros,reshape
+from pylab import array, reshape, zeros
 
 ################################################################
 ### misc library code

--- a/hocr-extract-g1000
+++ b/hocr-extract-g1000
@@ -2,8 +2,14 @@
 
 # extract lines from Google 1000 book sample
 
-import string,re,sys,os,shutil,glob
+import glob
+import os
+import re
+import shutil
+import string
+import sys
 import xml.sax
+
 from PIL import Image
 
 usage = """

--- a/hocr-extract-images
+++ b/hocr-extract-images
@@ -2,9 +2,15 @@
 
 # extract the images and texts within all the ocr_line elements within the hOCR file
 
-import sys,os,re,getopt,codecs
-from PIL import Image
+import codecs
+import getopt
+import os
+import re
+import sys
+
 from lxml import html
+from PIL import Image
+
 
 def assoc(key,list):
     for k,v in list:

--- a/hocr-lines
+++ b/hocr-lines
@@ -2,8 +2,12 @@
 
 # extract the text within all the ocr_line elements within the hOCR file
 
-import sys,os,re
+import os
+import re
+import sys
+
 from lxml import html
+
 
 def get_text(node):
     textnodes = node.xpath(".//text()")

--- a/hocr-merge-dc
+++ b/hocr-merge-dc
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 
-import sys,os,re
+import os
+import re
+import sys
 import xml
-from lxml import html, etree
+
+from lxml import etree, html
 
 dcknown = [
     "dc:title","dc:creator","dc:subject",

--- a/hocr-pdf
+++ b/hocr-pdf
@@ -17,19 +17,21 @@
 # Create a searchable PDF from a pile of HOCR + JPEG. Tested with
 # Tesseract.
 
-import sys
-import glob
-import os.path
-import io
 import base64
-import zlib
+import glob
+import io
+import os.path
 import re
+import sys
+import zlib
 
-from PIL import Image
-from reportlab.pdfgen.canvas import Canvas
 from reportlab.pdfbase import pdfmetrics
 from reportlab.pdfbase.ttfonts import TTFont
+from reportlab.pdfgen.canvas import Canvas
+
 from lxml import etree, html
+from PIL import Image
+
 
 class StdoutWrapper:
     """

--- a/hocr-split
+++ b/hocr-split
@@ -2,8 +2,12 @@
 
 # split an hOCR file into individual pages
 
-import sys,os,string,re
-from lxml import html, etree
+import os
+import re
+import string
+import sys
+
+from lxml import etree, html
 
 ################################################################
 ### main program

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ VERSION = '1.0.1'
 
 import glob
 from setuptools import setup
+
 setup(
     name = "hocr-tools",
     version = VERSION,


### PR DESCRIPTION
Imports should usually be on separate lines: e.g.:

```
Yes: import os
     import sys

No:  import sys, os
```