### PR TITLE
Fix hocr-combine, add tests

### DIFF
--- a/hocr-combine
+++ b/hocr-combine
@@ -33,7 +33,6 @@ for fname in sys.argv[2:]:
     doc2 = html.parse(fname)
     pages = doc2.xpath("//*[@class='ocr_page']")
     for page in pages:
-        page = doc.importNode(page,1)
         container.append(page)
 
-print(etree.tostring(doc, pretty_print=True))
+print(etree.tostring(doc, pretty_print=True).decode('UTF-8'))

--- a/test/hocr-combine/hocr-combine-lines.tsht
+++ b/test/hocr-combine/hocr-combine-lines.tsht
@@ -1,0 +1,10 @@
+#!/usr/bin/env tsht
+TESTDATA="../testdata"
+
+plan 2
+
+exec_ok "hocr-combine" "$TESTDATA/sample.html" "$TESTDATA/sample.html"
+
+nlines_sample=$(cat "$TESTDATA/sample.html" | grep -c ocr_line)
+nlines_result=$(hocr-combine "$TESTDATA/sample.html" "$TESTDATA/sample.html" | grep -c ocr_line)
+equals "$((2*$nlines_sample))" $nlines_result "check whether number ocr_lines in self-combined result is doubled"


### PR DESCRIPTION
This fixes the error
```
AttributeError: 'HtmlElement' object has no attribute 'importNode'
```
The function `importNode` does not exist in `etree` and it seems not necessary anymore.