### PR TITLE
Use always mixed case form "hOCR" in documentation and help texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Please see the documentation in the [tsht](https://github.com/kba/tsht) reposito
 take a look at the existing [unit tests](./test/).
 
 1) Create a new directory under `./test`
-2) Copy any test assets (images, hocr files...) to this directory
+2) Copy any test assets (images, hOCR files...) to this directory
 3) Create a file `<name-of-your-test>.tsht` starting from this template:
 
 ```sh

--- a/hocr-eval-geom
+++ b/hocr-eval-geom
@@ -56,8 +56,8 @@ def relative_overlap(u,v):
 ### argument parsing
 
 parser = argparse.ArgumentParser(description="Compute statistics about the quality of the geometric segmentation at the level of the given OCR element", epilog="The output is a 4-tuple (multiple,missing,error,count) for the truth compared with the actual and then again another 4-tuple in the other direction")
-parser.add_argument("truth", help="hocr file with ground truth", type=argparse.FileType('r'))
-parser.add_argument("actual", help="hocr file from the actual recognition", type=argparse.FileType('r'))
+parser.add_argument("truth", help="hOCR file with ground truth", type=argparse.FileType('r'))
+parser.add_argument("actual", help="hOCR file from the actual recognition", type=argparse.FileType('r'))
 parser.add_argument("-e", "--element", default="ocr_line", help="OCR element to look at, default: %(default)s")
 parser.add_argument("-o", "--significant_overlap", type=float, default=0.1, help="default: %(default)s")
 parser.add_argument("-c", "--close_match", type=float, default=0.9, help="default: %(default)s")

--- a/hocr-eval-lines
+++ b/hocr-eval-lines
@@ -57,7 +57,7 @@ def edit_distance(a,b,threshold=999999):
 
 parser = argparse.ArgumentParser(description="Compute statistics about the quality of the geometric segmentation at the level of the given OCR element")
 parser.add_argument("tfile", help="text file with the true lines", type=argparse.FileType('r'))
-parser.add_argument("hfile", help="hocr file with the actually recognized lines", type=argparse.FileType('r'))
+parser.add_argument("hfile", help="hOCR file with the actually recognized lines", type=argparse.FileType('r'))
 parser.add_argument("-v", "--verbose", action="store_true")
 args = parser.parse_args()
 

--- a/hocr-extract-g1000
+++ b/hocr-extract-g1000
@@ -23,7 +23,7 @@ Run ocroscript align-... Volume_0000/0000/0000.{png,txt}
 
 Arguments:
 
-    hocr: hocr source file
+    hocr: hOCR source file
 
     image_pattern: either a glob pattern that results in a list 
         of image files in order, or @filename for a file containing

--- a/hocr-merge-dc
+++ b/hocr-merge-dc
@@ -25,7 +25,7 @@ def get_text(node):
 
 parser = argparse.ArgumentParser(description="merge Dublin Core metadata into hOCR header files")
 parser.add_argument("dc", help="XML file with Dublin Core metadata", type=argparse.FileType('r'))
-parser.add_argument("hocr", help="hocr file", type=argparse.FileType('r'))
+parser.add_argument("hocr", help="hOCR file", type=argparse.FileType('r'))
 args = parser.parse_args()
 
 dc_doc = etree.parse(args.dc, html.XHTMLParser())


### PR DESCRIPTION
Signed-off-by: Stefan Weil <sw@weilnetz.de>