### PR TITLE
Adapt hocr-wordfreq for non-ASCII symbols

### DIFF
--- a/hocr-wordfreq
+++ b/hocr-wordfreq
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 from __future__ import print_function
 import sys
@@ -21,7 +21,7 @@ text = doc.find('//body').text_content().strip()
 if args.case_insensitive:
     text = text.lower()
 wc = {}
-for word in re.split('\W+', text):
+for word in re.compile('\W+', re.UNICODE).split(text):
     if word == '': continue
     wc[word] = wc[word]+1 if word in wc else 1
 

--- a/test/hocr-wordfreq/hocr-wordfreq.tsht
+++ b/test/hocr-wordfreq/hocr-wordfreq.tsht
@@ -9,5 +9,5 @@ casesensitive=$(hocr-wordfreq -i $TESTDATA/sample.html | head -n 1)
 exec_ok "hocr-wordfreq" "$TESTDATA/sample.html"
 exec_ok "hocr-wordfreq" "-i" "-n 30" "$TESTDATA/sample.html"
 
-match "24\s*the" "$normal" "check that no errors are found when comparing the sample file with itself"
-match "23\s*the" "$casesensitive" "check that no errors are found when comparing the sample file with itself"
+match "24\s*the" "$normal" "check the most frequent word in sample.html"
+match "23\s*the" "$casesensitive" "check the most frequent word (case-sensitive) in sample.html"

--- a/test/hocr-wordfreq/hocr-wordfreq.tsht
+++ b/test/hocr-wordfreq/hocr-wordfreq.tsht
@@ -9,5 +9,5 @@ casesensitive=$(hocr-wordfreq -i $TESTDATA/sample.html | head -n 1)
 exec_ok "hocr-wordfreq" "$TESTDATA/sample.html"
 exec_ok "hocr-wordfreq" "-i" "-n 30" "$TESTDATA/sample.html"
 
-match "24\s*the" "$normal" "check the most frequent word in sample.html"
-match "23\s*the" "$casesensitive" "check the most frequent word (case-sensitive) in sample.html"
+match "24\s*the" "$normal" "check that no errors are found when comparing the sample file with itself"
+match "23\s*the" "$casesensitive" "check that no errors are found when comparing the sample file with itself"


### PR DESCRIPTION
This is tested with the ersch (fraktur) example from ocropy.