### PR TITLE
Update sample.html: head information + image location

### DIFF
--- a/test/hocr-combine/test-hocr-combine.tsht
+++ b/test/hocr-combine/test-hocr-combine.tsht
@@ -5,6 +5,6 @@ plan 2
 
 exec_ok "hocr-combine" "$TESTDATA/sample.html" "$TESTDATA/sample.html"
 
-nlines_sample=$(cat "$TESTDATA/sample.html" | grep -c ocr_line)
-nlines_result=$(hocr-combine "$TESTDATA/sample.html" "$TESTDATA/sample.html" | grep -c ocr_line)
+nlines_sample=$(cat "$TESTDATA/sample.html" | grep -c "class=['\"]ocr_line['\"]")
+nlines_result=$(hocr-combine "$TESTDATA/sample.html" "$TESTDATA/sample.html" | grep -c "class=['\"]ocr_line['\"]")
 equals "$((2*$nlines_sample))" $nlines_result "check whether number ocr_lines in self-combined result is doubled"

--- a/test/hocr-merge-dc/hocr-merge-dc.tsht
+++ b/test/hocr-merge-dc/hocr-merge-dc.tsht
@@ -7,7 +7,7 @@ hocr_file='../testdata/sample.html'
 output=$(hocr-merge-dc dcsample2.xml "$hocr_file")
 not_ok "$?" "Command succeeded"
 # ok "$output" "Output produced"
-match "name='DC.title' content='Nomad'" "$(cat "$hocr_file")"
+match "name='DC.title' content='Alice im Wonderland'" "$(cat "$hocr_file")"
 not_match "name='DC.title' content='UKOLN'" "$(cat "$hocr_file")"
 match 'name="DC.title" content="UKOLN"' "$output"
 # match "

--- a/test/testdata/sample.html
+++ b/test/testdata/sample.html
@@ -1,14 +1,18 @@
-<html>
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" 
+    "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"> 
+<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
-  <title></title>
-  <meta name='ocr-id' content='OCRopus Revision: 312'>
-  <meta name='ocr-recognized' content='lines text'>
-  <meta name='DC.creator' content='James T. Kirk'>
-  <meta name='DC.title' content='Nomad'>
-  <meta name='DC.publisher' content='NASA'>
+  <title>OCR Results</title>
+  <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+  <meta name="ocr-system" content="ocropy-1.0" />
+  <meta name="ocr-capabilities" content="ocr_line ocr_page" />
+  <meta name='DC.creator' content='Lewis Carroll'>
+  <meta name='DC.title' content='Alice im Wonderland'>
+  <meta name='DC.publisher' content='Macmillan'>
 </head>
 <body>
-  <div class='ocr_page' title='file alice_1.png'>
+  <div class='ocr_page' title='image "alice_1.png"; bbox 0 0 2488 3507'>
     <h3><span class='ocr_line' title='bbox 467 525 1386 588'>1 Down the Rabbit-Hole</span></h3>
     <span class='ocr_line' title='bbox 461 648 2077 707'>Alice was beginning to get very tired of sitting by her sister on the bank,</span>
     <span class='ocr_line' title='bbox 461 708 2079 766'>and of having nothing to do: once or twice she had peeped into the book her</span>
@@ -44,7 +48,8 @@
       <span class='ocr_line' title='bbox 453 2086 2072 2145'>of time as she went down to look about her and to wonder what was going</span>
       <span class='ocr_line' title='bbox 452 2146 2071 2198'>to happen next. First, she tried to look down and make out what she was</span>
       <span class='ocr_line' title='bbox 452 2207 2071 2262'>coming to, but it Was too dark to see anything; then she looked at the sides</span>
-      <span class='ocr_line' title='bbox 451 2265 2070 2323'>of the well, and noticed that they were filled with cupboards and book</span><span class='ocr_line' title='bbox 451 2325 2071 2384'>shelves; here and there she saw maps and pictures hung upon pegs. She took</span>
+      <span class='ocr_line' title='bbox 451 2265 2070 2323'>of the well, and noticed that they were filled with cupboards and book</span>
+      <span class='ocr_line' title='bbox 451 2325 2071 2384'>shelves; here and there she saw maps and pictures hung upon pegs. She took</span>
       <span class='ocr_line' title='bbox 451 2385 2070 2442'>down a jar from one of the shelves as she passed; it was labelled `ORANGE</span>
       <span class='ocr_line' title='bbox 451 2445 2068 2504'>MARMALADE', but to her great disappointment it was empty: she did not</span>
       <span class='ocr_line' title='bbox 450 2507 2069 2565'>like to drop the jar for fear of killing somebody, so managed to put it into</span>


### PR DESCRIPTION
This should solve https://github.com/tmbdev/hocr-tools/issues/102 which was reported by @stweil during some testing.

(Note: I did not change the recognition result itself, also it seems that the OCRopus output slightly differs especially on apostrophes and exclamation marks.)