### PR TITLE
Extend hocr-pdf to work also with lines

### DIFF
--- a/hocr-pdf
+++ b/hocr-pdf
@@ -83,7 +83,12 @@ def add_text_layer(pdf, image, height, dpi):
       baseline = [ 0, 0 ]
     linebox = [float(i) for i in linebox]
     baseline = [float(i) for i in baseline]
-    for word in line.xpath('.//*[@class="ocrx_word"]'):
+    xpath_elements = './/*[@class="ocrx_word"]'
+    if (not(line.xpath('boolean(' + xpath_elements + ')'))):
+      #if there are no words elements present,
+      #we switch to lines as elements
+      xpath_elements = '.'
+    for word in line.xpath(xpath_elements):
       rawtext = word.text_content().strip()
       if rawtext == '':
           continue


### PR DESCRIPTION
If there are no ocrx_word's present in the hocr output
then we switch to use the ocr_line's instead. This is
especially needed for the current output of ocropy.

See also #106.