### PR TITLE
Fix compat with windows by adding savefile arguement to hocr-pdf

### DIFF
--- a/hocr-pdf
+++ b/hocr-pdf
@@ -157,7 +157,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--savefile",
-        help="Where to save the file (ex: C:\\Users\\test.pdf)"
+        help="Save to this file instead of outputting to stdout"
     )
     args = parser.parse_args()
     export_pdf(args.imgdir, 300, args.savefile)


### PR DESCRIPTION
I couldn't get hocr-pdf to work in windows because it outputs to stdout and windows doesn't handle the latin1 encoding very well (and created corrupt PDFs for me even when using `chcp 65001` and `set PYTHONIOENCODING=utf-8`) . I was able to get this to work by adding an optional argument for which file to save the document to (instead of outputting to stdout).

I would have preferred to use a Linux OS but the company I work for uses windows servers. This update makes it work for both without having to deal with the encoding headache.