### PR TITLE
Fix negative bounding boxes

### DIFF
--- a/hocr-pdf
+++ b/hocr-pdf
@@ -157,7 +157,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--savefile",
-        help="Where to save the file (ex: C:\\Users\\test.pdf)"
+        help="Save to this file instead of outputting to stdout"
     )
     args = parser.parse_args()
     export_pdf(args.imgdir, 300, args.savefile)

--- a/hocr-pdf
+++ b/hocr-pdf
@@ -73,7 +73,7 @@ def export_pdf(playground, default_dpi, savefile=False):
 
 def add_text_layer(pdf, image, height, dpi):
     """Draw an invisible text layer for OCR data"""
-    p1 = re.compile('bbox((\s+\d+){4})')
+    p1 = re.compile('bbox((\s+[\d\-]+){4})')
     p2 = re.compile('baseline((\s+[\d\.\-]+){2})')
     hocrfile = os.path.splitext(image)[0] + ".hocr"
     hocr = etree.parse(hocrfile, html.XHTMLParser())


### PR DESCRIPTION
Fixes #127 

Negative bounding boxes are now correctly matched and doesn't make the program crash fatally.