### PR TITLE
Remove unused import statements

### DIFF
--- a/hocr-check
+++ b/hocr-check
@@ -4,9 +4,6 @@
 
 from __future__ import print_function
 import argparse
-import os
-import re
-import string
 import sys
 
 from lxml import html

--- a/hocr-combine
+++ b/hocr-combine
@@ -2,10 +2,6 @@
 
 from __future__ import print_function
 import argparse
-import os
-import re
-import string
-import sys
 
 from lxml import etree, html
 

--- a/hocr-eval
+++ b/hocr-eval
@@ -6,11 +6,7 @@
 
 from __future__ import print_function
 import argparse
-import codecs
-import os
 import re
-import string
-import sys
 
 from lxml import html
 from PIL import Image, ImageDraw

--- a/hocr-eval-geom
+++ b/hocr-eval-geom
@@ -5,9 +5,7 @@
 
 from __future__ import print_function
 import argparse
-import os
 import re
-import sys
 
 from lxml import html
 

--- a/hocr-eval-lines
+++ b/hocr-eval-lines
@@ -5,9 +5,7 @@
 
 from __future__ import print_function
 import argparse
-import os
 import re
-import sys
 
 from lxml import html
 

--- a/hocr-extract-g1000
+++ b/hocr-extract-g1000
@@ -6,8 +6,6 @@ from __future__ import print_function
 import glob
 import os
 import re
-import shutil
-import string
 import sys
 import xml.sax
 

--- a/hocr-lines
+++ b/hocr-lines
@@ -4,7 +4,6 @@
 
 from __future__ import print_function
 import argparse
-import os
 import re
 import sys
 

--- a/hocr-merge-dc
+++ b/hocr-merge-dc
@@ -2,10 +2,7 @@
 
 from __future__ import print_function
 import argparse
-import os
 import re
-import sys
-import xml
 
 from lxml import etree, html
 

--- a/hocr-split
+++ b/hocr-split
@@ -4,10 +4,7 @@
 
 from __future__ import print_function
 import argparse
-import os
 import re
-import string
-import sys
 
 from lxml import etree, html
 


### PR DESCRIPTION
This fixes most warnings from lgtm
(https://lgtm.com/projects/g/tmbdev/hocr-tools/alerts).

Signed-off-by: Stefan Weil <sw@weilnetz.de>