### PR TITLE
Alternative travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ matrix:
       sudo: true
 cache: pip
 install:
-  - pip install cython
+  - python -m pip install --upgrade pip setuptools wheel
+  - pip install Cython>=27.3
   - pip install -r requirements.txt
   - python setup.py install
   # - pip install pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 cache: pip
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ matrix:
       sudo: true
 cache: pip
 install:
-  - python -m pip install --upgrade pip setuptools wheel
-  - pip install Cython>=27.3
+  - pip install https://files.pythonhosted.org/packages/22/94/d4ad8d2d107af92ee6c517400ea98c23221bd89785e37bc3b76777649bda/lxml-4.2.4-cp37-cp37m-manylinux1_x86_64.whl
   - pip install -r requirements.txt
   - python setup.py install
   # - pip install pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       sudo: true
 cache: pip
 install:
-  - pip install -r cython
+  - pip install cython
   - pip install -r requirements.txt
   - python setup.py install
   # - pip install pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-cache:
-  directories:
-    - /home/travis/virtualenv/python2.7/lib/python2.7/site-packages
-    - /home/travis/virtualenv/python3.4/lib/python3.4/site-packages
-    - /home/travis/virtualenv/python3.5/lib/python3.5/site-packages
-    - /home/travis/virtualenv/python3.6/lib/python3.6/site-packages
+cache: pip
 install:
   - pip install -r requirements.txt
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 cache: pip
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
       sudo: true
 cache: pip
 install:
-  - pip install https://files.pythonhosted.org/packages/22/94/d4ad8d2d107af92ee6c517400ea98c23221bd89785e37bc3b76777649bda/lxml-4.2.4-cp37-cp37m-manylinux1_x86_64.whl
+  # - pip install https://files.pythonhosted.org/packages/22/94/d4ad8d2d107af92ee6c517400ea98c23221bd89785e37bc3b76777649bda/lxml-4.2.4-cp37-cp37m-manylinux1_x86_64.whl
   - pip install -r requirements.txt
   - python setup.py install
   # - pip install pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "3.7"
+  - "3.7-dev"
 # Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
 matrix:
   include:
@@ -13,6 +13,7 @@ matrix:
       sudo: true
 cache: pip
 install:
+  - pip install -r cython
   - pip install -r requirements.txt
   - python setup.py install
   # - pip install pep8

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,8 @@ python:
   - "3.5"
   - "3.6"
   - "3.7-dev"
-# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial
-      sudo: true
 cache: pip
 install:
-  # - pip install https://files.pythonhosted.org/packages/22/94/d4ad8d2d107af92ee6c517400ea98c23221bd89785e37bc3b76777649bda/lxml-4.2.4-cp37-cp37m-manylinux1_x86_64.whl
   - pip install -r requirements.txt
   - python setup.py install
   # - pip install pep8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 Pillow==3.1.1
-lxml==3.5.0
+lxml>=3.5.0
 reportlab==3.3.0

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Multimedia :: Graphics :: Graphics Conversion',
         'Topic :: Scientific/Engineering :: Image Recognition',
         'Topic :: Utilities',


### PR DESCRIPTION
Okay, this toke several attempts, but now we have something which is working:
* allowed more recent pip packages for `lxml` for which also in Python 3.7 a wheel package can be found and therefore no build from source is needed which failed previously
* for some reason Python `3.7-dev` works w/o any hack
* switch to `cache: pip` as suggested in https://docs.travis-ci.com/user/caching/#pip-cache CC @kba

This superseeds #133.

The commit here need to be squashed before merged.